### PR TITLE
Supress command output when checking if repository has changes

### DIFF
--- a/git-multi
+++ b/git-multi
@@ -103,7 +103,7 @@ def is_ignored( project ):
 	return file_name in ignore_projects
 
 def is_changed():
-	executed, changed_lines = execute_command( 'git status --porcelain' )
+	executed, changed_lines = execute_command( 'git status --porcelain', output = False)
 	return changed_lines
 
 # Used when group_by_output == True, keys are output, values are a list of projects


### PR DESCRIPTION
Fix the -c flag. To illustrate the problem, here is an example of asking
for a status summary of only those repositories that have changes.

Before:

```
$ ls -1
a/
b/
c/

$ git multi -c status -sb

Executing:git status -sb

M file1
b:
    ## master
    M file1
?? file2
c:
    ## master
    ?? file2
```

After:

```
$ git-multi -c status -sb

Executing:git status -sb

b:
    ## master
    M file1
c:
    ## master
    ?? file2
```
